### PR TITLE
Hotfix: Error messages in clean

### DIFF
--- a/config/pacman-yay-config.sh
+++ b/config/pacman-yay-config.sh
@@ -7,6 +7,9 @@ UNINSTALL_COMMAND () {
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {
   yay -S --noconfirm $@
+  # yay does not return error codes on some errors (package not found for example)
+  # This is a workaround return error code if the package was not installed
+  pacman -Qq $@ > /dev/null 2>&1 || return 1
 }
 # Command to list all manually/explicitely installed packages
 LIST_COMMAND () {

--- a/src/commands/clean.sh
+++ b/src/commands/clean.sh
@@ -2,10 +2,11 @@
 
 SHRBINDIR=$(dirname $BASH_SOURCE)
 source $SHRBINDIR/utils.sh
+RETURN_CODE=0
 
 function remove_stray {
   # Remove packages not in KEEPLISTFILE
-  echo -e ":: Removing stray packages ::\n"
+  echo -e "(1/2) Removing stray packages\n"
 
   # Save packages list into string, not run command
   STRAY_PKGS=$(get_stray_pkgs | xargs)
@@ -13,7 +14,19 @@ function remove_stray {
   if [[ -n $STRAY_PKGS ]]; then
     echo -e "The following $(echo $STRAY_PKGS | wc -w) package(s) are strayed (installed but not declared in packages.list):\n\t$STRAY_PKGS"
     echo -e "Uninstalling..."
-    UNINSTALL_COMMAND $STRAY_PKGS > /dev/null && echo -e "Done."
+    
+
+    OUTPUT="$(UNINSTALL_COMMAND $STRAY_PKGS 2>&1)"
+    STATUS=$?
+
+    if [[ $STATUS -ne 0 ]]; then
+      echo -e "Manual intervention required. There was an error while uninstalling:\n"
+      echo -e "=== START OUTPUT ===\n$OUTPUT\n=== END OUTPUT ==="
+      RETURN_CODE=1
+    else
+      echo -e "Done."
+    fi
+
   else 
     echo "There are no stray packages. Nothing to remove."
   fi
@@ -21,14 +34,25 @@ function remove_stray {
 
 function install_missing {
   # Install packages in KEEPLISTFILE
-  echo -e ":: Installing missing packages ::\n"
+  echo -e "(2/2) Installing missing packages\n"
 
   MISSING_PKGS=$(get_missing_pkgs | xargs)
 
   if [[ -n $MISSING_PKGS ]]; then
     echo -e "The following $(echo $MISSING_PKGS | wc -w) package(s) are missing (declared in packages.list but not installed):\n\t$MISSING_PKGS"
     echo -e "Installing..."
-    INSTALL_COMMAND $MISSING_PKGS > /dev/null && echo -e "Done."
+
+    OUTPUT="$(INSTALL_COMMAND $MISSING_PKGS 2>&1)"
+    STATUS=$?
+
+    if [[ $STATUS -ne 0 ]]; then
+      echo -e "Manual intervention required. There was an error while installing:\n"
+      echo -e "=== START OUTPUT ===\n$OUTPUT\n=== END OUTPUT ==="
+      RETURN_CODE=1
+    else
+      echo -e "Done."
+    fi
+
   else
     echo "There are no missing packages. Nothing to install."
   fi
@@ -39,6 +63,7 @@ function main {
   remove_stray
   printf "\n"
   install_missing
+  return $RETURN_CODE
 }
 
 main

--- a/src/commands/clean.sh
+++ b/src/commands/clean.sh
@@ -3,8 +3,10 @@
 SHRBINDIR=$(dirname $BASH_SOURCE)
 source $SHRBINDIR/utils.sh
 
-function clean {
+function remove_stray {
   # Remove packages not in KEEPLISTFILE
+  echo -e ":: Removing stray packages ::\n"
+
   # Save packages list into string, not run command
   STRAY_PKGS=$(get_stray_pkgs | xargs)
 
@@ -15,8 +17,12 @@ function clean {
   else 
     echo "There are no stray packages. Nothing to remove."
   fi
+}
 
+function install_missing {
   # Install packages in KEEPLISTFILE
+  echo -e ":: Installing missing packages ::\n"
+
   MISSING_PKGS=$(get_missing_pkgs | xargs)
 
   if [[ -n $MISSING_PKGS ]]; then
@@ -26,13 +32,13 @@ function clean {
   else
     echo "There are no missing packages. Nothing to install."
   fi
-
-  echo "Cleaning done."
 }
 
 function main {
   ASSERT_KEEPFILE_EXISTS
-  clean
+  remove_stray
+  printf "\n"
+  install_missing
 }
 
 main

--- a/test/test_cases/data/config-errors.sh
+++ b/test/test_cases/data/config-errors.sh
@@ -1,0 +1,15 @@
+# Mock package manager interactions 
+LIST_COMMAND () {
+  echo -e "pkg1\npkg2\npkg5"
+}
+INSTALL_COMMAND () {
+  echo "test case error message install"
+  return 1
+}
+UNINSTALL_COMMAND () {
+  echo "test case error message uninstall"
+  return 1
+}
+sudo () {
+  $@
+}

--- a/test/test_cases/test.bats
+++ b/test/test_cases/test.bats
@@ -72,18 +72,18 @@ pkg4"
 
 @test "declaro clean removes and installs packages" {
   run declaro clean
-  assert_line -n 0 "The following 1 package(s) are strayed (installed but not declared in packages.list):"
-  assert_line -n 1 -e "\spkg5"
-  assert_line -n 4 "The following 2 package(s) are missing (declared in packages.list but not installed):"
-  assert_line -n 5 -e "\spkg3 pkg4"
+  assert_line -n 1 "The following 1 package(s) are strayed (installed but not declared in packages.list):"
+  assert_line -n 2 -e "\spkg5"
+  assert_line -n 6 "The following 2 package(s) are missing (declared in packages.list but not installed):"
+  assert_line -n 7 -e "\spkg3 pkg4"
 }
 
 @test "declaro clean does nothing if no packages are strayed or missing" {
   export DECLAROCONFFILE="$DIR/data/config-clean-state.sh"
 
   run declaro clean
-  assert_line -n 0 "There are no stray packages. Nothing to remove."
-  assert_line -n 1 "There are no missing packages. Nothing to install."
+  assert_line -n 1 "There are no stray packages. Nothing to remove."
+  assert_line -n 3 "There are no missing packages. Nothing to install."
 }
 
 @test "declaro diff works" {

--- a/test/test_cases/test.bats
+++ b/test/test_cases/test.bats
@@ -78,6 +78,14 @@ pkg4"
   assert_line -n 7 -e "\spkg3 pkg4"
 }
 
+@test "declaro clean deals with errors in installing and uninstalling" {
+  export DECLAROCONFFILE="$DIR/data/config-errors.sh"
+  run declaro clean
+  assert_output --partial "test case error message uninstall"
+  assert_output --partial "test case error message install"
+  
+}
+
 @test "declaro clean does nothing if no packages are strayed or missing" {
   export DECLAROCONFFILE="$DIR/data/config-clean-state.sh"
 


### PR DESCRIPTION
When the underlying package manager fails when installing or uninstalling (by running declaro clean), declaro will not request the user for manual intervention and print the error.

Also fix yay config so it is supported by this feature

Closes #10 