### PR TITLE
Changed "install" to "uninstall" where spotted and looked like it should have been "uninstall"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ neovim # My favorite text editor
 `declaro` was written to be package manager agnostic. As such, integrating with a package manager is as simple as defining three functions in a config file at `/etc/declaro/config.sh`. Consider our [`apt-config.sh`](config/apt-config.sh) for Ubuntu systems:
 
 ```bash
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
   sudo apt-get remove $@ -y
 }

--- a/config/apt-config.sh
+++ b/config/apt-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
   sudo apt-get remove $@ -y
 }

--- a/config/dnf-config.sh
+++ b/config/dnf-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
         sudo dnf remove --assumeyes $@
 }

--- a/config/pacman-config.sh
+++ b/config/pacman-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
   sudo pacman -Rns --noconfirm $@
 }

--- a/config/pacman-paru-config.sh
+++ b/config/pacman-paru-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
   sudo pacman -Rns --noconfirm $@
 }

--- a/config/pacman-yay-config.sh
+++ b/config/pacman-yay-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
   sudo pacman -Rns --noconfirm $@
 }

--- a/config/template-config.sh
+++ b/config/template-config.sh
@@ -1,6 +1,6 @@
 KEEPLISTFILE="/etc/declaro/packages.list"
 
-# Command to install a package and its dependencies (no confirm/user prompts)
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
 
 }


### PR DESCRIPTION
The comment above the uninstall command said "Command to install", so I changed it to "Command to uninstall"

```bash
# Command to uninstall a package and its dependencies (no confirm/user prompts) UNINSTALL_COMMAND () {
  sudo apt-get remove $@ -y
  ```