### PR TITLE
Add Homebrew support in MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ SHRBINDIR = $(SHRDIR)/declaro/bin
 SHRCONFDIR = $(SHRDIR)/declaro/config
 ETC_DECLARO_DIR = /etc/declaro
 
+# Helpers
+MKDIR_P ?= mkdir -p
+
 .PHONY: all install uninstall test
 
 all:
@@ -14,6 +17,13 @@ all:
 
 install:
 	@echo "Installing declaro..."
+
+	$(SUDO) $(MKDIR_P) \
+	  $(DESTDIR)$(BINDIR) \
+	  $(DESTDIR)$(SHRBINDIR) \
+	  $(DESTDIR)$(SHRCONFDIR) \
+	  $(DESTDIR)$(ETC_DECLARO_DIR)
+
 	$(SUDO) install -Dm755 src/declaro.sh $(DESTDIR)$(BINDIR)/declaro
 	$(SUDO) install -Dm644 src/commands/clean.sh $(DESTDIR)$(SHRBINDIR)/clean.sh
 	$(SUDO) install -Dm644 src/commands/diff.sh $(DESTDIR)$(SHRBINDIR)/diff.sh

--- a/config/brew-config.sh
+++ b/config/brew-config.sh
@@ -1,0 +1,14 @@
+KEEPLISTFILE="/etc/declaro/packages.list"
+
+# Command to uninstall a package and its dependencies (no confirm/user prompts)
+UNINSTALL_COMMAND () {
+  brew remove $@
+}
+# Command to install a package and its dependencies (no confirm/user prompts)
+INSTALL_COMMAND () {
+  brew install $@
+}
+# Command to list all manually/explicitely installed packages
+LIST_COMMAND () {
+  brew list
+}

--- a/src/commands/install-config.sh
+++ b/src/commands/install-config.sh
@@ -15,6 +15,7 @@ CONFIG_FILE_TABLE=(
   'pacman with yay   ; pacman --version && pacman -Qq yay     ; pacman-yay-config.sh'
   # has to be after paru and yay
   'pacman w/out AUR  ; pacman --version                       ; pacman-config.sh'
+  'brew              ; brew --version                         ; brew-config.sh'
 )
 
 


### PR DESCRIPTION
Add support support for homebrew in MacOS and fix make file install.

`install` does not support `-D` on MacOS so added `mkdir -p` to Makefile