### PR TITLE
Added Fedora repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ If you would like to help us and add official support for your package manager, 
 git clone https://aur.archlinux.org/declaro-git.git && cd declaro-git && makepkg -si
 ```
 
+- For **Fedora** you can download from COPR. Enable the COPR first:
+
+```bash
+dnf copr enable xariann/tools 
+```
+Then install declaro:
+```
+sudo dnf install declaro
+```
+
 ### Manual Installation
 
 1. Make sure you have the following the dependencies installed:


### PR DESCRIPTION
I have packaged this in a COPR that people can use for Fedora if they wish to. I added it in the README file. Please bear in mind though that Fedora package guidelines need a licence (see related issue #35)  so if you were at all able to add one then I can update it also in the COPR.

Once we have a licence, I will do a second pull request with the update .spec file that contains the correct licence. 