### PR TITLE
feature: multiple-packages-per-line (#4)

### DIFF
--- a/src/utils.sh
+++ b/src/utils.sh
@@ -34,8 +34,8 @@ function ASSERT_KEEPFILE_EXISTS {
 }
 
 function parse_keepfile {
-  # Remove comments, remove whitespace and remove empty lines, then sort
-  sed -e 's/#.*$//' -e 's/[ \t]*//g' -e '/^\s*$/d' $1 | sort
+  # Remove comments, trim lines, convert whitespaces between words into newlines, and remove empty lines, then sort
+  sed -e 's/#.*$//' -e 's/^[ \t\r]*//' -e 's/[ \t\r]*$//' -e 's/[ \t\r]\+/\n/g' -e '/^\s*$/d' $1 | sort
 }
 
 # Prints the packages in one and not the other, and vice-versa


### PR DESCRIPTION
# Closes #4 
Updated `sed` parsing logic in `parse_keepfile`. Converts spaces or tabs between package names into newlines, effectively allowing users to list multiple packages on a single line, while also trimming the whitespaces from both sides.