### PR TITLE
Fix issues with explicit installed dependencies

### DIFF
--- a/config/pacman-config.sh
+++ b/config/pacman-config.sh
@@ -2,11 +2,13 @@ KEEPLISTFILE="/etc/declaro/packages.list"
 
 # Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
-  sudo pacman -Rns --noconfirm $@
+  sudo pacman -D --asdeps $@
+  sudo pacman -Qdtq | sudo pacman -Rns --noconfirm -
 }
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {
-  sudo pacman -S --noconfirm $@
+  sudo pacman -S --noconfirm --needed $@
+  sudo pacman -D --asexplicit $@
 }
 # Command to list all manually/explicitely installed packages
 LIST_COMMAND () {

--- a/config/pacman-paru-config.sh
+++ b/config/pacman-paru-config.sh
@@ -2,7 +2,8 @@ KEEPLISTFILE="/etc/declaro/packages.list"
 
 # Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
-  sudo pacman -Rns --noconfirm $@
+  sudo pacman -D --asdeps $@
+  sudo pacman -Qdtq | sudo pacman -Rns --noconfirm -
 }
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {

--- a/config/pacman-paru-config.sh
+++ b/config/pacman-paru-config.sh
@@ -8,6 +8,7 @@ UNINSTALL_COMMAND () {
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {
   paru -S --noconfirm $@
+  sudo pacman -D --asexplicit $@
 }
 # Command to list all manually/explicitely installed packages
 LIST_COMMAND () {

--- a/config/pacman-yay-config.sh
+++ b/config/pacman-yay-config.sh
@@ -2,7 +2,8 @@ KEEPLISTFILE="/etc/declaro/packages.list"
 
 # Command to uninstall a package and its dependencies (no confirm/user prompts)
 UNINSTALL_COMMAND () {
-  sudo pacman -Rns --noconfirm $@
+  sudo pacman -D --asdeps $@
+  sudo pacman -Qdtq | sudo pacman -Rns --noconfirm -
 }
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {

--- a/config/pacman-yay-config.sh
+++ b/config/pacman-yay-config.sh
@@ -8,6 +8,7 @@ UNINSTALL_COMMAND () {
 # Command to install a package and its dependencies (no confirm/user prompts)
 INSTALL_COMMAND () {
   yay -S --noconfirm $@
+  sudo pacman -D --asexplicit $@
   # yay does not return error codes on some errors (package not found for example)
   # This is a workaround return error code if the package was not installed
   pacman -Qq $@ > /dev/null 2>&1 || return 1


### PR DESCRIPTION
This fixes various cases where uninstalling of a explicit installed package that is a dependency of an other explicit installed package did not work.
This changes the state of packages to dep/explicit and removes orphans

related to #29 